### PR TITLE
Update the README to avoid runtime panic

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ wasmer publish .
 You can also use `wasmer run-unstable` to test things locally.
 
 ```console
-$ wasmer run-unstable .
+$ wasmer run-unstable --env SCRIPT_NAME=hello .
 INFO run: wasmer_wasix::runners::wcgi::runner: Starting the server address=127.0.0.1:8000 command_name="server"
 ```
 


### PR DESCRIPTION
This is a small fix in the README to update the instruction to run this CGI locally,

If it is executed by `wasmer run-unstable .`, It crashes when it receives a request.

```
thread 'main' panicked at 'no entry found for key', /home/syuparn/.cargo/registry/src/github.com-1ecc6299db9ec823/cgi-0.6.0/src/lib.rs:263:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2023-05-03T08:50:47.042755Z ERROR ThreadId(05) wasmer_wasix::runners::wcgi::handler: Unable to drive the request to completion error=Runtime error error.sources=[RuntimeError: unreachable
...
```

This is due to [cgi crate](https://github.com/amandasaurus/rust-cgi/blob/v0.6.0/src/lib.rs#L36) and we should specify required environment variables explicitly.

```bash
wasmer run-unstable --env SCRIPT_NAME=hello .
```